### PR TITLE
fix: buggy test when checking whether to install recommends or not

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -100,7 +100,7 @@ APT_OPTIONS=("-o" "debug::nolocking=true" "-o" "dir::cache=$APT_CACHE_DIR" "-o" 
 APT_OPTIONS+=("-o" "dir::etc::sourcelist=$APT_SOURCES" "-o" "dir::etc::sourceparts=$APT_SOURCEPARTS_DIR")
 
 # Check whether we want recommended packages or not (default is True):
-if [ -v "${APT_DONT_INSTALL_RECOMMENDS}" ]; then
+if [ -v APT_DONT_INSTALL_RECOMMENDS ]; then
     APT_OPTIONS+=("-o" "APT::Install-Recommends" "False")
 fi
 


### PR DESCRIPTION
See https://github.com/Scalingo/apt-buildpack/pull/18#issuecomment-2765951678 for context and bug report.