### PR TITLE
fix: pass value for `APT::Install-Recommends` option correctly

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -99,9 +99,9 @@ APT_OPTIONS=("-o" "debug::nolocking=true" "-o" "dir::cache=$APT_CACHE_DIR" "-o" 
 # Override the use of /etc/apt/sources.list (sourcelist) and /etc/apt/sources.list.d/* (sourceparts).
 APT_OPTIONS+=("-o" "dir::etc::sourcelist=$APT_SOURCES" "-o" "dir::etc::sourceparts=$APT_SOURCEPARTS_DIR")
 
-# Check whether we want recommended packages or not (default is True):
+# Check whether we want recommended packages or not (default is true):
 if [ -v APT_DONT_INSTALL_RECOMMENDS ]; then
-    APT_OPTIONS+=("-o" "APT::Install-Recommends" "False")
+    APT_OPTIONS+=("-o" "APT::Install-Recommends=false")
 fi
 
 topic "Updating APT package index"


### PR DESCRIPTION
See https://github.com/Scalingo/apt-buildpack/pull/18#issuecomment-2768340820 for context